### PR TITLE
Adicionando provider no endereço e atualizando APIs

### DIFF
--- a/src/Address.php
+++ b/src/Address.php
@@ -45,7 +45,14 @@ class Address
     public $zipCode;
 
     /**
-     * Cria uma nova instância da classe a partir de um array associativo.
+     * A identificação do provider que retornou os dados do endereço.
+     *
+     * @var string
+     */
+    public $provider;
+
+    /**
+     * Cria uma instância da classe a partir de um array associativo.
      *
      * @param  array  $data
      * @return Address

--- a/src/CepPromise.php
+++ b/src/CepPromise.php
@@ -122,7 +122,7 @@ class CepPromise
                 CorreiosProvider::createPromiseArray($cepWithLeftPad)
             );
 
-            return Promise\any($promises);
+            return Promise\Utils::any($promises);
         };
     }
 

--- a/src/Providers/CepAbertoProvider.php
+++ b/src/Providers/CepAbertoProvider.php
@@ -27,7 +27,7 @@ class CepAbertoProvider extends BaseProvider
      */
     public function makePromise(string $cep)
     {
-        $url = "http://www.cepaberto.com/api/v2/ceps.json?cep=$cep";
+        $url = "https://www.cepaberto.com/api/v3/cep?cep=$cep";
         $httpVerb = 'GET';
         $options = [
             'headers' => [
@@ -73,6 +73,7 @@ class CepAbertoProvider extends BaseProvider
                 'city' => $responseArray['cidade'],
                 'district' => $responseArray['bairro'],
                 'street' => $responseArray['logradouro'],
+                'provider' => $this->providerIdentifier,
             ];
         };
     }

--- a/src/Providers/CorreiosProvider.php
+++ b/src/Providers/CorreiosProvider.php
@@ -63,6 +63,7 @@ class CorreiosProvider extends BaseProvider
                     'city' => $responseArray['cidade'],
                     'district' => $responseArray['bairro'],
                     'street' => $responseArray['end'],
+                    'provider' => $this->providerIdentifier,
                 ];
             }
 

--- a/src/Providers/ViaCepProvider.php
+++ b/src/Providers/ViaCepProvider.php
@@ -53,7 +53,7 @@ class ViaCepProvider extends BaseProvider
     private function checkForViaCepError()
     {
         return function (array $responseArray) {
-            if (isset($responseArray['erro']) && true === $responseArray['erro']) {
+            if (isset($responseArray['erro'])) {
                 throw new Exception('CEP não encontrado na base do ViaCEP.');
             }
 
@@ -70,6 +70,7 @@ class ViaCepProvider extends BaseProvider
                 'city' => $responseArray['localidade'],
                 'district' => $responseArray['bairro'],
                 'street' => $responseArray['logradouro'],
+                'provider' => $this->providerIdentifier,
             ];
         };
     }

--- a/tests/Unit/CepPromiseUnitTest.php
+++ b/tests/Unit/CepPromiseUnitTest.php
@@ -78,6 +78,7 @@ class CepPromiseUnitTest extends TestCase
             'state' => 'SE',
             'street' => 'Avenida Presidente Juscelino Kubitschek',
             'zipCode' => '49060535',
+            'provider' => 'inline_provider_from_tests',
         ];
     }
 
@@ -94,6 +95,7 @@ class CepPromiseUnitTest extends TestCase
         $address->street = 'Avenida Presidente Juscelino Kubitschek';
         $address->district = 'Santo Antônio';
         $address->zipCode = '49060535';
+        $address->provider = 'inline_provider_from_tests';
 
         return $address;
     }


### PR DESCRIPTION
A classe `Address` agora tem como um de seus atributos a identificação do provider que forneceu aquele endereço.

Foram feitas correções em algumas APIs que mudaram ou foram atualizadas.
